### PR TITLE
fixing the 'all files in path' example to use -t rather than -f

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Evaluating: cloudfront_distribution_without_logging.json
 Validate all files in a path
 
 ``` {.sourceCode .console}
-$cfn-validator validate -f /projects
+$cfn-validator validate -t /projects
 ...
 ```
 


### PR DESCRIPTION
Simple docs update so that `Validate all files in a path` uses the ` -t, --template-path ` rather than the ` -f, --template-file ` flag

To validate the bug run the given command against a directory containing cloudformation files:

```bash
$ cfn-validator validate -f /src

Evaluating: /src
[
]
```

To validate the update in this PR run the updated sample text against a directory containing some cloudformation files:

```bash
$ cfn-validator validate -t /src

Evaluating: /src/demo.json

##############################
Invalid json file - /src/demo.json - skipping file
################################

The failing function was audit  - ValidateUtility - line number: 387
error:Illegal cfn - no Resources - ValidateUtility - line number: 388
[
        {
                "failure_count": "1",
                "filename": "/src/demo.json",
                "file_results": [
                        {
                                "id": "FATAL",
                                "type": "VIOLATION::FAILING_VIOLATION",
                                "message": {"Illegal cfn - no Resources": "None"},
                                "logical_resource_ids": "None"
                        }
                ]
        }
]
```